### PR TITLE
Added Exception inheritance checking

### DIFF
--- a/src/MSTestExtensions.Tests/ThrowsTests.cs
+++ b/src/MSTestExtensions.Tests/ThrowsTests.cs
@@ -87,5 +87,47 @@ namespace MSTestExtensions.Tests
             // Act & Assert
             Assert.Throws(() => { throw new ArgumentNullException("username"); }, expectedMessage, ExceptionMessageCompareOptions.Contains);
         }
+
+        [TestMethod]
+        public void FunctionThrowsInheritedException()
+        {
+            // Arrange
+            Action<string> method = (x) => { throw new ArgumentNullException(); };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => method("some param"));
+        }
+
+        [TestMethod]
+        public void MethodThrowsInheritedException()
+        {
+            // Arrange
+            Action<string> method = (x) => { throw new ArgumentNullException(); };
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => method("some param"));
+        }
+
+        [TestMethod]
+        public void FunctionThrowsNonInheritedException()
+        {
+            // Arrange
+            Action<string> method = (x) => { throw new ArgumentNullException(); };
+            Action invalidAssert = () => { Assert.Throws<ArgumentException>(() => method("some param"), ExceptionInheritanceOptions.Exact); };
+
+            // Act & Assert
+            Assert.Throws<AssertFailedException>(() => invalidAssert());
+        }
+
+        [TestMethod]
+        public void MethodThrowsNonInheritedException()
+        {
+            // Arrange
+            Action<string> method = (x) => { throw new ArgumentNullException(); };
+            Action invalidAssert = () => { Assert.Throws<ArgumentException>(() => method("some param"), ExceptionInheritanceOptions.Exact); };
+
+            // Act & Assert
+            Assert.Throws<AssertFailedException>(() => invalidAssert());
+        }
     }
 }

--- a/src/MSTestExtensions/ExceptionAssert.cs
+++ b/src/MSTestExtensions/ExceptionAssert.cs
@@ -8,7 +8,7 @@ namespace MSTestExtensions
     [DebuggerNonUserCode]
     public static class ExceptionAssert
     {
-        public static void Throws<T>(Action task, string expectedMessage, ExceptionMessageCompareOptions options) where T : Exception
+        public static void Throws<T>(Action task, string expectedMessage, ExceptionMessageCompareOptions messageOptions, ExceptionInheritanceOptions inheritOptions) where T : Exception
         {
             try
             {
@@ -16,8 +16,8 @@ namespace MSTestExtensions
             }
             catch (Exception ex)
             {
-                AssertExceptionType<T>(ex);
-                AssertExceptionMessage(ex, expectedMessage, options);
+                AssertExceptionType<T>(ex, inheritOptions);
+                AssertExceptionMessage(ex, expectedMessage, messageOptions);
                 return;
             }
 
@@ -33,66 +33,82 @@ namespace MSTestExtensions
 
         #region Overloaded methods
 
-        public static void Throws<T>(this IAssertion assertion, Action task) where T : Exception
+        public static void Throws<T>(this IAssertion assertion, Action task, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits) where T : Exception
         {
-            Throws<T>(task, null, ExceptionMessageCompareOptions.None);
+            Throws<T>(task, null, ExceptionMessageCompareOptions.None, inheritOptions);
         }
 
-        public static void Throws<T>(Action task) where T : Exception
+        public static void Throws<T>(Action task, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits) where T : Exception
         {
-            Throws<T>(task, null, ExceptionMessageCompareOptions.None);
+            Throws<T>(task, null, ExceptionMessageCompareOptions.None, inheritOptions);
         }
 
-        public static void Throws<T>(this IAssertion assertion, Action task, string expectedMessage) where T : Exception
+        public static void Throws<T>(this IAssertion assertion, Action task, string expectedMessage, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits) where T : Exception
         {
-            Throws<T>(task, expectedMessage, ExceptionMessageCompareOptions.Exact);
+            Throws<T>(task, expectedMessage, ExceptionMessageCompareOptions.Exact, inheritOptions);
         }
 
-        public static void Throws<T>(Action task, string expectedMessage) where T : Exception
+        public static void Throws<T>(Action task, string expectedMessage, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits) where T : Exception
         {
-            Throws<T>(task, expectedMessage, ExceptionMessageCompareOptions.Exact);
+            Throws<T>(task, expectedMessage, ExceptionMessageCompareOptions.Exact, inheritOptions);
         }
 
-        public static void Throws<T>(this IAssertion assertion, Action task, string expectedMessage, ExceptionMessageCompareOptions options) where T : Exception
+        public static void Throws<T>(this IAssertion assertion, Action task, string expectedMessage, ExceptionMessageCompareOptions options, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits) where T : Exception
         {
-            Throws<T>(task, expectedMessage, options);
+            Throws<T>(task, expectedMessage, options, inheritOptions);
         }
 
-        public static void Throws(this IAssertion assertion, Action task, string expectedMessage, ExceptionMessageCompareOptions options)
+        public static void Throws(this IAssertion assertion, Action task, string expectedMessage, ExceptionMessageCompareOptions options, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, expectedMessage, options);
+            Throws<Exception>(task, expectedMessage, options, inheritOptions);
         }
 
-        public static void Throws(Action task, string expectedMessage, ExceptionMessageCompareOptions options)
+        public static void Throws(Action task, string expectedMessage, ExceptionMessageCompareOptions options, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, expectedMessage, options);
+            Throws<Exception>(task, expectedMessage, options, inheritOptions);
         }
 
-        public static void Throws(this IAssertion assertion, Action task, string expectedMessage)
+        public static void Throws(this IAssertion assertion, Action task, string expectedMessage, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, expectedMessage, ExceptionMessageCompareOptions.Exact);
+            Throws<Exception>(task, expectedMessage, ExceptionMessageCompareOptions.Exact, inheritOptions);
         }
 
-        public static void Throws(Action task, string expectedMessage)
+        public static void Throws(Action task, string expectedMessage, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, expectedMessage, ExceptionMessageCompareOptions.Exact);
+            Throws<Exception>(task, expectedMessage, ExceptionMessageCompareOptions.Exact, inheritOptions);
         }
 
-        public static void Throws(this IAssertion assertion, Action task)
+        public static void Throws(this IAssertion assertion, Action task, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, null, ExceptionMessageCompareOptions.None);
+            Throws<Exception>(task, null, ExceptionMessageCompareOptions.None, inheritOptions);
         }
 
-        public static void Throws(Action task)
+        public static void Throws(Action task, ExceptionInheritanceOptions inheritOptions = ExceptionInheritanceOptions.Inherits)
         {
-            Throws<Exception>(task, null, ExceptionMessageCompareOptions.None);
+            Throws<Exception>(task, null, ExceptionMessageCompareOptions.None, inheritOptions);
         }
 
         #endregion
 
-        private static void AssertExceptionType<T>(Exception ex)
+        private static void AssertExceptionNotInherited<T>(Exception ex)
+        {
+            Assert.IsFalse(ex.GetType().IsSubclassOf(typeof(T)));
+        }
+
+        private static void AssertExceptionType<T>(Exception ex, ExceptionInheritanceOptions options)
         {
             Assert.IsInstanceOfType(ex, typeof(T), "Expected exception type failed.");
+            switch (options)
+            {
+                case ExceptionInheritanceOptions.Exact:
+                    AssertExceptionNotInherited<T>(ex);
+                    break;
+                case ExceptionInheritanceOptions.Inherits:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("options");
+
+            }
         }
 
         private static void AssertExceptionMessage(Exception ex, string expectedMessage, ExceptionMessageCompareOptions options)

--- a/src/MSTestExtensions/ExceptionInheritanceOptions.cs
+++ b/src/MSTestExtensions/ExceptionInheritanceOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace MSTestExtensions
+{
+    public enum ExceptionInheritanceOptions
+    {
+        None,
+        Exact,
+        Inherits
+    }
+}

--- a/src/MSTestExtensions/MSTestExtensions.csproj
+++ b/src/MSTestExtensions/MSTestExtensions.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Assertion.cs" />
     <Compile Include="BaseTest.cs" />
     <Compile Include="ExceptionAssert.cs" />
+    <Compile Include="ExceptionInheritanceOptions.cs" />
     <Compile Include="ExceptionMessageCompareOptions.cs" />
     <Compile Include="IAssertion.cs" />
     <Compile Include="MsTestAssertions.cs" />


### PR DESCRIPTION
Pull request for bbraithwaite/MSTestExtensions#3, criticisms, concerns, and suggestions happily accepted

Implemented the change as a required argument to the main `ExceptionAssert.Throws<T>`, and as an optional argument to all of the extension methods. All optional uses default to `.Inherits` so that the old behavior is observed, and an exception type such as `ArgumentNullException` is accepted when an `ArgumentException` was expected.

Following the use of `ExceptionMessageCompareOptions`, use of `.None` throws an exception during type checking such that one cannot provide an "empty" value while also explicitly providing a value.

For users who inherited `BaseClass` and use the extension methods, these changes will not break anything. Users manually calling `ExceptionAssert.Throws<T>` will receive a build error indicating that the new argument must be provided. This could potentially be solved by either providing it as an optional argument, supplying `.Inherits` as the default, or by just adding XML documentation to the enum's values so users know what each is for.
