### PR TITLE
Swapped expected/actual exception message

### DIFF
--- a/src/MSTestExtensions/ExceptionAssert.cs
+++ b/src/MSTestExtensions/ExceptionAssert.cs
@@ -118,7 +118,7 @@ namespace MSTestExtensions
                 switch (options)
                 {
                     case ExceptionMessageCompareOptions.Exact:
-                        Assert.AreEqual(ex.Message.ToUpper(), expectedMessage.ToUpper(), "Expected exception message failed.");
+                        Assert.AreEqual(expectedMessage.ToUpper(), ex.Message.ToUpper(), "Expected exception message failed.");
                         break;
                     case ExceptionMessageCompareOptions.Contains:
                         Assert.IsTrue(ex.Message.Contains(expectedMessage), string.Format("Expected exception message does not contain <{0}>.", expectedMessage));


### PR DESCRIPTION
The first argument to `Assert.AreEqual` is the expected value, and the second is the actual value. The values being passed in `AssertExceptionMessage` were backwards, which can be confusing when evaluating test failures.
