### PR TITLE
Format markdown and link to MS Test V2 as related

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Add Extension Methods to Assert in MSTest
+# Add Extension Methods to Assert in MSTest
 
-An extendible implementation of the Assert class in MSTest. Allows for extending the Assert methods whilst retaining the default Assert. methods. Also includes a Throws() method for asserting exceptions.
+An extendible implementation of the `Assert` class in MSTest. Allows for extending the Assert methods whilst retaining the default Assert methods. Also includes a `Throws()` method for asserting exceptions.
 
-##What Problem Does it Solve?
+## What Problem Does it Solve?
 
-I wanted to be able to add my own extension methods to *Assert* e.g. **Assert.Throws()** but keeping the existing default MSTest methods. 
+I wanted to be able to add my own extension methods to *Assert* e.g. **Assert.Throws()** but keeping the existing default MSTest methods.
 
 e.g.
 
@@ -14,7 +14,7 @@ public void AddWithNegativeNumberThrowsExceptionExpectedMessage()
 {
     // Arrange
     StringCalculator sc = new StringCalculator();
-  
+
     // Act => Assert
     Assert.Throws(() => sc.Add("-1"), "you cannot supply negative numbers.");
 }
@@ -22,29 +22,28 @@ public void AddWithNegativeNumberThrowsExceptionExpectedMessage()
 
 To accommodate such syntax I had to write this wrapper.
 
-##Get Started
+## Get Started
 
-1. Add the MsTestExtensions.dll lib to your project (I'm assuming you may have downloaded the package from Nuget to do this: package name = MsTestExtensions).
+1. Add the MsTestExtensions.dll lib to your project. (I'm assuming you may have downloaded the package from Nuget to do this: package name = MsTestExtensions.)
 
-2. Add a using/import MsTestExtensions entry within your class.
+2. Add a using/import `MsTestExtensions` entry within your class.
 
-3. Inherit from BaseTest with the Test Class you are using and you should see Assert.Throws(...) in intellisense.
-  * If you would rather not inherit from BaseTest you can use the syntax: 
-    * ThrowsAssert.Throws(...)
-    * ThrowsAsyncAssert.Throws(...)
-  * Lastly if the above options do not suite, you can add the following within your test class: public static readonly IAssertion Assert = new Assertion();
+3. Inherit from `BaseTest` with the Test Class you are using and you should see `Assert.Throws(...)` in intellisense.
+   * If you would rather not inherit from `BaseTest` you can use the syntax:
+     * `ThrowsAssert.Throws(...)`
+     * `ThrowsAsyncAssert.Throws(...)`
+   * Lastly if the above options do not suite, you can add the following within your test class: `public static readonly IAssertion Assert = new Assertion();`
 
+NB: `IAssertion` is the interface to use for adding your own custom extensions.
 
-NB IAssertion is the interface to use for adding your own custom extensions.
-
-For more details see the accompanying [blog post] (http://www.bradoncode.com/blog/2012/02/extending-assert-in-mstest.html).
+For more details see the accompanying [blog post](<http://www.bradoncode.com/blog/2012/02/extending-assert-in-mstest.html>).
 
 ## Features
 
 ### Assert Exceptions are thrown
 
-* Assert.Throws()
-* Assert.ThrowsAsync()
+* `Assert.Throws()`
+* `Assert.ThrowsAsync()`
 
 Example:
 
@@ -59,7 +58,7 @@ Assert.Throws<T>()
 Assert.ThrowsAsync<T>()
 ```
 
-Where the type T must be the exception type. Example:  
+Where the type T must be the exception type. Example:
 
 ``` csharp
 Assert.Throws<ArgumentNullException>(() => { throw ArgumentNullException(); });
@@ -72,7 +71,7 @@ There are options to assert the exception type:
 
 ## Assert an Exception Message
 
-It's possible to assert the message of the exception. Example:
+It is possible to assert the message of the exception. Example:
 
 ``` csharp
 Assert.Throws(() => { throw new ArgumentNullException("username"); }, "Value cannot be null." + Environment.NewLine + "Parameter name: username";);
@@ -80,18 +79,23 @@ Assert.Throws(() => { throw new ArgumentNullException("username"); }, "Value can
 
 There are options to assert the exception message:
 
-* Exact (the default case)
-* Contains (for partial matching - [See example](https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs#L125))
-* IgnoreCase (case of string is ignored - [See example](https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs#L112))
+* `Exact` (the default case)
+* `Contains` (for partial matching - [See example](https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs#L125))
+* `IgnoreCase` (case of string is ignored - [See example](https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs#L112))
 
-For more examples, see the unit tests: https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs
+For more examples, see the unit tests: <https://github.com/bbraithwaite/MSTestExtensions/blob/master/src/MSTestExtensions.Tests/ThrowsTests.cs>
 
 ## Versioning
 
 Latest version is 4.0.0.
 
-Available via Nuget: https://www.nuget.org/packages/MSTestExtensions/4.0.0
+Available via Nuget: <https://www.nuget.org/packages/MSTestExtensions/4.0.0>
 
-##License
+## License
 
-MIT license - http://www.opensource.org/licenses/mit-license.php
+MIT license - <http://www.opensource.org/licenses/mit-license.php>
+
+## Related
+
+In the mean time `ThrowsException` and `ThrowsExceptionAsync` are included in
+[Micorosft MSTest V2](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.testtools.unittesting.assert.throwsexception?view=mstest-net-1.2.0).


### PR DESCRIPTION
Fixed some formating of markdown and added a link to Microsoft.VisualStudio.TestTools.UnitTesting.Assert.ThrowsException